### PR TITLE
Bug - EDavki requires unique dividend Day/ISIN/Type entries

### DIFF
--- a/src/InfoProviders/InfoLookupProvider.py
+++ b/src/InfoProviders/InfoLookupProvider.py
@@ -14,7 +14,9 @@ class TreatyType(str, Enum):
 class Country:
     name: str
     shortCode2: str
-    treaties: dict[TreatyType, str] # https://www.gov.si/drzavni-organi/ministrstva/ministrstvo-za-finance/o-ministrstvu/direktorat-za-sistem-davcnih-carinskih-in-drugih-javnih-prihodkov/seznam-veljavnih-konvencij-o-izogibanju-dvojnega-obdavcevanja-dohodka-in-premozenja/
+    treaties: dict[TreatyType, str] 
+    # https://www.gov.si/drzavni-organi/ministrstva/ministrstvo-za-finance/o-ministrstvu/direktorat-za-sistem-davcnih-carinskih-in-drugih-javnih-prihodkov/seznam-veljavnih-konvencij-o-izogibanju-dvojnega-obdavcevanja-dohodka-in-premozenja/
+    # https://www.fu.gov.si/davki_in_druge_dajatve/podrocja/mednarodno_obdavcenje/#c78
 
     def __init__(self, name: str, shortCode2: str, treaties: dict[TreatyType, str]):
         self.name = name

--- a/src/ReportingStrategies/Slovenia/ReportGeneration.py
+++ b/src/ReportingStrategies/Slovenia/ReportGeneration.py
@@ -10,6 +10,8 @@ from src.ConfigurationProvider.Configuration import ReportBaseConfig
 from dataclasses import dataclass
 import arrow
 
+
+
 # https://edavki.durs.si/EdavkiPortal/PersonalPortal/[360253]/Pages/Help/sl/WorkflowType1.htm
 class EDavkiDocumentWorkflowType(str, Enum):
     ORIGINAL = "O"
@@ -82,6 +84,39 @@ class EDavkiDividendReport(gr.GenericDividendReport[EDavkiReportConfig]):
             gf.GenericDividendLineType.DIVIDEND: dividendLines,
             gf.GenericDividendLineType.WITHOLDING_TAX: witholdingTax
         }
+    
+    def mergeSameDividendsForUniqueDayIsinType(self, dividends: list[ss.EDavkiDividendReportLine]) -> list[ss.EDavkiDividendReportLine]:
+        segmented: dict[str, list[ss.EDavkiDividendReportLine]] = {}
+        for key, valuesiter in groupby(dividends, key=lambda dividend: "{}-{}-{}".format(dividend.DateReceived, dividend.DividendType, dividend.DividendPayerAddress)):
+            segmented[key] = list(v for v in valuesiter)
+
+        mergedDividends: list[ss.EDavkiDividendReportLine] = list()
+
+        for dividendList in segmented.values():
+            combinedTotal = sum(map(lambda dividend: dividend.DividendAmount, dividendList))
+            combinedTotalTax = sum(map(lambda dividend: dividend.ForeignTaxPaid, dividendList))
+
+            combinedTracking = '-'.join(list(map(lambda dividend: dividend.DividendIdentifierForTracking, dividendList)))
+
+            generatedMerged = ss.EDavkiDividendReportLine(
+                DateReceived = dividendList[0].DateReceived,
+                TaxNumberForDividendPayer = dividendList[0].TaxNumberForDividendPayer,
+                DividendPayerIdentificationNumber = dividendList[0].DividendPayerIdentificationNumber,
+                DividendPayerTitle = dividendList[0].DividendPayerTitle,
+                DividendPayerAddress = dividendList[0].DividendPayerAddress,
+                DividendPayerCountryOfOrigin = dividendList[0].DividendPayerCountryOfOrigin,
+                DividendType = dividendList[0].DividendType,
+                CountryOfOrigin = dividendList[0].CountryOfOrigin,
+                DividendIdentifierForTracking = combinedTracking,
+                TaxReliefParagraphInInternationalTreaty = dividendList[0].TaxReliefParagraphInInternationalTreaty,
+                DividendAmount = combinedTotal,
+                ForeignTaxPaid = combinedTotalTax
+            )
+
+            mergedDividends.append(generatedMerged)
+
+        return mergedDividends
+
     
     def calculateLines(self, data: list[gf.GenericDividendLine]) -> list[ss.EDavkiDividendReportLine]:
         actionToDividendMapping : dict[str, ss.EDavkiDividendReportLine] = dict()
@@ -171,7 +206,9 @@ class EDavkiDividendReport(gr.GenericDividendReport[EDavkiReportConfig]):
                 print("Failed for ISIN: " + dividendLine.DividendPayerIdentificationNumber)
                 print(e)
 
-        return createdLines
+        combinedLines = self.mergeSameDividendsForUniqueDayIsinType(createdLines)
+
+        return combinedLines
 
     def generateDataFrameReport(self, data: list[gf.GenericDividendLine]) -> pd.DataFrame:
         lines = self.calculateLines(data)
@@ -316,7 +353,7 @@ class EDavkiTradesReport(gr.GenericTradesReport[EDavkiReportConfig]):
                     buyLines: list[gf.GenericTradeReportItemSecurityLineBought] = list(filter(lambda line: isinstance(line, gf.GenericTradeReportItemSecurityLineBought), lots.Lines)) # type: ignore
                     sellLines: list[gf.GenericTradeReportItemSecurityLineSold] = list(filter(lambda line: isinstance(line, gf.GenericTradeReportItemSecurityLineSold), lots.Lines)) # type: ignore
 
-                    buyLines = list(filter(lambda line: line.AcquiredDate >= periodStart and line.AcquiredDate < periodEnd, buyLines))
+                    # buyLines = list(filter(lambda line: line.AcquiredDate >= periodStart and line.AcquiredDate < periodEnd, buyLines))
                     sellLines = list(filter(lambda line: line.SoldDate >= periodStart and line.SoldDate < periodEnd, sellLines))
 
                     buys = list(map(convertBuy, buyLines)) # type: ignore


### PR DESCRIPTION
Having 2 dividend events on the same day for the same company causes an error on EDavki, as the platform requires unique combinations of when a dividend was added, who the dividend was received from, and the type of dividend received.