### PR TITLE
QoL - Add more currency info to exports to match with broker reports

### DIFF
--- a/src/TaxAuthorityProvider/TaxAuthorities/Slovenia/ReportGeneration/KDVP/Common.py
+++ b/src/TaxAuthorityProvider/TaxAuthorities/Slovenia/ReportGeneration/KDVP/Common.py
@@ -46,7 +46,13 @@ def convertStockBuy(
         GainType=GAIN_MAPPINGS[line.AcquiredReason],
         Quantity=line.ExchangedMoney.UnderlyingQuantity,
         PricePerUnit=line.ExchangedMoney.UnderlyingTradePrice,
+        PricePerUnitInOriginalCurrency=line.ExchangedMoney.UnderlyingTradePrice * (1 / line.ExchangedMoney.FxRateToBase),
         TotalPrice=line.ExchangedMoney.UnderlyingQuantity * line.ExchangedMoney.UnderlyingTradePrice,
+        TotalPriceInOriginalCurrency=line.ExchangedMoney.UnderlyingQuantity
+        * line.ExchangedMoney.UnderlyingTradePrice
+        * (1 / line.ExchangedMoney.FxRateToBase),
+        Commissions=line.ExchangedMoney.ComissionTotal,
+        CommissionsInOriginalCurrency=line.ExchangedMoney.ComissionTotal * (1 / line.ExchangedMoney.FxRateToBase),
         InheritanceAndGiftTaxPaid=None,
         BaseTaxReduction=None,
     )
@@ -59,7 +65,13 @@ def convertStockSell(
         SoldOn=line.Date,
         Quantity=line.ExchangedMoney.UnderlyingQuantity,
         PricePerUnit=line.ExchangedMoney.UnderlyingTradePrice,
+        PricePerUnitInOriginalCurrency=line.ExchangedMoney.UnderlyingTradePrice * (1 / line.ExchangedMoney.FxRateToBase),
         TotalPrice=line.ExchangedMoney.UnderlyingQuantity * line.ExchangedMoney.UnderlyingTradePrice,
+        TotalPriceInOriginalCurrency=line.ExchangedMoney.UnderlyingQuantity
+        * line.ExchangedMoney.UnderlyingTradePrice
+        * (1 / line.ExchangedMoney.FxRateToBase),
+        Commissions=line.ExchangedMoney.ComissionTotal,
+        CommissionsInOriginalCurrency=line.ExchangedMoney.ComissionTotal * (1 / line.ExchangedMoney.FxRateToBase),
         SatisfiesTaxBasisReduction=False,  # TODO: Wash sale handling
     )
 

--- a/src/TaxAuthorityProvider/TaxAuthorities/Slovenia/Schemas/Schemas.py
+++ b/src/TaxAuthorityProvider/TaxAuthorities/Slovenia/Schemas/Schemas.py
@@ -64,7 +64,11 @@ class EDavkiTradeReportSecurityLineGenericEventBought:
     GainType: EDavkiTradeReportGainType
     Quantity: float
     PricePerUnit: float
+    PricePerUnitInOriginalCurrency: float
     TotalPrice: float
+    TotalPriceInOriginalCurrency: float
+    Commissions: float
+    CommissionsInOriginalCurrency: float
     InheritanceAndGiftTaxPaid: float | None
     BaseTaxReduction: float | None
 
@@ -74,7 +78,11 @@ class EDavkiTradeReportSecurityLineGenericEventSold:
     SoldOn: Arrow
     Quantity: float
     TotalPrice: float
+    TotalPriceInOriginalCurrency: float
     PricePerUnit: float
+    PricePerUnitInOriginalCurrency: float
+    Commissions: float
+    CommissionsInOriginalCurrency: float
     SatisfiesTaxBasisReduction: bool
 
 


### PR DESCRIPTION
Adds original currency prices and commissions to spreadsheet exports, for easier matching with broker exports.