### PR TITLE
Fix - Don't include inheritence in export if it's not present

### DIFF
--- a/src/TaxAuthorityProvider/TaxAuthorities/Slovenia/ReportGeneration/KDVP/XML_Doh_KDVP.py
+++ b/src/TaxAuthorityProvider/TaxAuthorities/Slovenia/ReportGeneration/KDVP/XML_Doh_KDVP.py
@@ -95,9 +95,9 @@ def generateXmlReport(
                         etree.SubElement(purchase, "F5").text = str(
                             entryLine.InheritanceAndGiftTaxPaid.__round__(5) if entryLine.InheritanceAndGiftTaxPaid is not None else "0"
                         )
-                        etree.SubElement(purchase, "F11").text = str(
-                            entryLine.BaseTaxReduction.__round__(5) if entryLine.BaseTaxReduction is not None else "0"
-                        )
+
+                        if entryLine.BaseTaxReduction is not None:
+                            etree.SubElement(purchase, "F11").text = str(entryLine.BaseTaxReduction.__round__(5))
 
                     if isinstance(entryLine, ss.EDavkiTradeReportSecurityLineGenericEventSold):
                         sale = etree.SubElement(row, "Sale")


### PR DESCRIPTION
EDavki complains otherwise that you need to fill in some document information, even if the value is 0.